### PR TITLE
feat: Add rate limiting to the root handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "express-rate-limit": "^5.2.6",
     "libphonenumber-js": "^1.7.56",
     "material-ui": "^0.20.2",
     "react": "^16.13.1",

--- a/server.js
+++ b/server.js
@@ -3,8 +3,14 @@ const fs = require("fs");
 const fileUpload = require("express-fileupload");
 const cors = require("cors");
 const morgan = require("morgan");
+const rateLimit = require("express-rate-limit");
 
 const app = express();
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100 // limit each IP to 100 requests per windowMs
+});
 
 app.use(
   fileUpload({
@@ -17,7 +23,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(morgan("dev"));
 
-app.post("/", async (req, res) => {
+app.post("/", limiter, async (req, res) => {
   try {
     if (req.files && req.files.files) {
       [req.files.files].flat().map((file) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4515,6 +4515,11 @@ express-fileupload@^1.1.7-alpha.3:
   dependencies:
     busboy "^0.3.1"
 
+express-rate-limit@^5.2.6:
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-5.2.6.tgz#b454e1be8a252081bda58460e0a25bf43ee0f7b0"
+  integrity sha512-nE96xaxGfxiS5jP3tD3kIW1Jg9yQgX0rXCs3rCkZtmbWHEGyotwaezkLj7bnB41Z0uaOLM8W4AX6qHao4IZ2YA==
+
 express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"


### PR DESCRIPTION
Fixes #11 

## Proposed Changes

  - installed `express-rate-limit`
  - set up rate limiting on the `/` handler
