### PR TITLE
Add mention of react-hook-form version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ---
 
+This project is currently written for [React Hook Form V6](https://react-hook-form.com/v6/api/).
+
 This is example repo for the [Ultimate React Hook Form Youtube video](https://www.youtube.com/watch?v=U-iz8b4RExA)
 
 The form features include:


### PR DESCRIPTION
Related: https://github.com/satansdeer/ultimate-react-hook-form-form/issues/28

## Proposed Changes

  - Prominently references in README the version of react-hook-form this was written for.